### PR TITLE
Added support for regional locales in getPluralIndex

### DIFF
--- a/MessageSelector.php
+++ b/MessageSelector.php
@@ -109,6 +109,11 @@ class MessageSelector
      */
     public function getPluralIndex($locale, $number)
     {
+        // Extract the locale from regional locales (e.g. "en_US" or "en-US").
+        if (strpos($locale, '-') or strpos($locale, '_')) {
+            $locale = explode('-', str_replace('_', '-', $locale))[0];
+        }
+
         switch ($locale) {
             case 'az':
             case 'bo':

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
-        "illuminate/filesystem": "5.4.*",
-        "illuminate/support": "5.4.*"
+        "php": ">=7.0",
+        "illuminate/filesystem": "5.5.*",
+        "illuminate/support": "5.5.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.4-dev"
+            "dev-master": "5.5-dev"
         }
     },
     "config": {


### PR DESCRIPTION
The getPluralIndex method was only matching "en", "fr", "de" etc., so I've added in a check to extract the locale for regional locales, so that "en_GB" or "en-US" becomes "en".